### PR TITLE
Scala 2.12, Akka 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ way, if your consumer fails to process the request or is disconnected, the broke
   }
   // wait 10 seconds and shut down
   Thread.sleep(10000)
-  system.shutdown()
+  system.terminate()
 
 ```
 
@@ -334,7 +334,7 @@ This is very useful if you want to break a single operation into multiple, paral
   }
   // wait 10 seconds and shut down
   Thread.sleep(10000)
-  system.shutdown()
+  system.terminate()
 
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,32 +2,28 @@ name := "amqp-client"
 
 organization := "com.kinja"
  
-version := "1.5.1" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
+version := "1.5.1" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
  
-scalaVersion := "2.11.6"
+crossScalaVersions := Seq("2.11.8", "2.12.6")
 
-scalacOptions  ++= Seq("-feature", "-language:postfixOps")
+scalaVersion := crossScalaVersions.value.head
  
-resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
+val akkaVersion = "2.5.11"
 
-resolvers += "Gawker Public Group" at "https://nexus.kinja-ops.com/nexus/content/groups/public/"
-
-libraryDependencies <<= scalaVersion { scala_version =>
-    val akkaVersion   = "2.3.12"
-    Seq(
-        "com.typesafe.akka"    %% "akka-actor"          % akkaVersion % "provided",
-        "com.rabbitmq"         % "amqp-client"          % "3.2.1",
-        "com.typesafe.akka"    %% "akka-testkit"        % akkaVersion  % "test",
-        "org.scalatest"        %% "scalatest"           % "2.2.4" % "test",
-        "junit"                % "junit"                % "4.11" % "test",
-        "com.typesafe.akka"    %% "akka-slf4j"          % akkaVersion % "provided",
-        "ch.qos.logback"       %  "logback-classic"     % "1.0.0" % "provided"
-    )
-}
-
-credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
-
-publishTo <<= (version)(version =>
-    if (version endsWith "SNAPSHOT") Some("Gawker Snapshots" at "https://nexus.kinja-ops.com/nexus/content/repositories/snapshots/")
-    else                             Some("Gawker Releases" at "https://nexus.kinja-ops.com/nexus/content/repositories/releases/")
+scalacOptions ++= Seq(
+	"-feature",
+	"-deprecation",
+	"-language:postfixOps"
 )
+
+libraryDependencies ++= Seq(
+	"com.typesafe.akka"    %% "akka-actor"          % akkaVersion % Provided,
+	"com.rabbitmq"         % "amqp-client"          % "3.2.1",
+	"com.typesafe.akka"    %% "akka-testkit"        % akkaVersion  % Test,
+	"org.scalatest"        %% "scalatest"           % "3.0.5" % Test,
+	"junit"                % "junit"                % "4.12" % Test,
+	"com.typesafe.akka"    %% "akka-slf4j"          % akkaVersion % Provided,
+	"ch.qos.logback"       %  "logback-classic"     % "1.0.0" % Provided
+)
+
+testOptions in Test := Seq.empty

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,8 @@
-// Comment to get more information during initialization
-logLevel := Level.Warn
+resolvers :=
+	Seq("Kinja Public Group" at sys.env.get("KINJA_PUBLIC_REPO").getOrElse("https://kinjajfrog.jfrog.io/kinjajfrog/sbt-virtual"),
+	"sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/")
 
-resolvers += "Gawker Public Group" at "https://nexus.kinja-ops.com/nexus/content/groups/public"
+credentials += Credentials(Path.userHome / ".ivy2" / ".kinja-artifactory.credentials")
 
-credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
-
-// The Typesafe repository
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+// Kinja build plugin
+addSbtPlugin("com.kinja.sbtplugins" %% "kinja-build-plugin" % "3.2.1")

--- a/src/main/scala/com/github.sstone/amqp/Amqp.scala
+++ b/src/main/scala/com/github.sstone/amqp/Amqp.scala
@@ -1,6 +1,6 @@
 package com.github.sstone.amqp
 
-import collection.JavaConversions._
+import collection.JavaConverters._
 import com.rabbitmq.client.AMQP.BasicProperties
 import com.rabbitmq.client.{AMQP, ShutdownSignalException, Channel, Envelope}
 import akka.actor.{Actor, Props, ActorRef, ActorRefFactory}
@@ -30,7 +30,7 @@ object Amqp {
     if (q.passive)
       channel.queueDeclarePassive(q.name)
     else
-      channel.queueDeclare(q.name, q.durable, q.exclusive, q.autodelete, q.args)
+      channel.queueDeclare(q.name, q.durable, q.exclusive, q.autodelete, q.args.asJava)
   }
 
   /**
@@ -54,7 +54,7 @@ object Amqp {
     if (e.passive)
       channel.exchangeDeclarePassive(e.name)
     else
-      channel.exchangeDeclare(e.name, e.exchangeType, e.durable, e.autodelete, e.args)
+      channel.exchangeDeclare(e.name, e.exchangeType, e.durable, e.autodelete, e.args.asJava)
   }
 
   object StandardExchanges {

--- a/src/main/scala/com/github.sstone/amqp/ChannelOwner.scala
+++ b/src/main/scala/com/github.sstone/amqp/ChannelOwner.scala
@@ -2,7 +2,7 @@ package com.github.sstone.amqp
 
 import java.util.UUID._
 
-import collection.JavaConversions._
+import collection.JavaConverters._
 import com.rabbitmq.client.AMQP.BasicProperties
 import com.rabbitmq.client._
 import akka.actor._
@@ -94,11 +94,11 @@ object ChannelOwner {
       }
       case request@QueueBind(queue, exchange, routingKey, args) => {
         log.debug("binding queue {} to key {} on exchange {}", queue, routingKey, exchange)
-        sender ! withChannel(channel, request)(c => c.queueBind(queue, exchange, routingKey, args))
+        sender ! withChannel(channel, request)(c => c.queueBind(queue, exchange, routingKey, args.asJava))
       }
       case request@QueueUnbind(queue, exchange, routingKey, args) => {
         log.debug("unbinding queue {} to key {} on exchange {}", queue, routingKey, exchange)
-        sender ! withChannel(channel, request)(c => c.queueUnbind(queue, exchange, routingKey, args))
+        sender ! withChannel(channel, request)(c => c.queueUnbind(queue, exchange, routingKey, args.asJava))
       }
       case request@Get(queue, autoAck) => {
         log.debug("getting from queue {} autoAck {}", queue, autoAck)

--- a/src/main/scala/com/github.sstone/amqp/Consumer.scala
+++ b/src/main/scala/com/github.sstone/amqp/Consumer.scala
@@ -6,7 +6,7 @@ import com.rabbitmq.client.{Envelope, Channel, DefaultConsumer}
 import com.rabbitmq.client.AMQP.BasicProperties
 import akka.event.LoggingReceive
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 object Consumer {
   def props(listener: Option[ActorRef], autoack: Boolean = false, init: Seq[Request] = Seq.empty[Request], channelParams: Option[ChannelParameters] = None,
@@ -66,7 +66,7 @@ class Consumer(listener: Option[ActorRef],
       log.debug("processing %s".format(request))
       sender ! withChannel(channel, request)(c => {
         val queueName = declareQueue(c, queue).getQueue
-        val actualConsumerTag = c.basicConsume(queueName, autoack, consumerTag, noLocal, exclusive, arguments, consumer.get)
+        val actualConsumerTag = c.basicConsume(queueName, autoack, consumerTag, noLocal, exclusive, arguments.asJava, consumer.get)
         log.debug(s"using consumer $actualConsumerTag")
         actualConsumerTag
       })
@@ -81,7 +81,7 @@ class Consumer(listener: Option[ActorRef],
         declareExchange(c, binding.exchange)
         val queueName = declareQueue(c, binding.queue).getQueue
         c.queueBind(queueName, binding.exchange.name, binding.routingKey)
-        val actualConsumerTag = c.basicConsume(queueName, autoack, consumerTag, noLocal, exclusive, arguments, consumer.get)
+        val actualConsumerTag = c.basicConsume(queueName, autoack, consumerTag, noLocal, exclusive, arguments.asJava, consumer.get)
         log.debug(s"using consumer $actualConsumerTag")
         actualConsumerTag
       })

--- a/src/main/scala/com/github.sstone/amqp/samples/Admin.scala
+++ b/src/main/scala/com/github.sstone/amqp/samples/Admin.scala
@@ -31,7 +31,7 @@ class AdminActor extends Actor {
   def connected(channel: ActorRef) : Receive = {
     case Amqp.Ok(request: DeclareQueue, Some(result: Queue.DeclareOk)) => {
       println(s"there are ${result.getMessageCount} in queue ${result.getQueue}")
-      context.system.shutdown()
+      context.system.terminate()
     }
   }
 }

--- a/src/main/scala/com/github.sstone/amqp/samples/Consumer1.scala
+++ b/src/main/scala/com/github.sstone/amqp/samples/Consumer1.scala
@@ -52,5 +52,5 @@ object Consumer1 extends App {
   println("press enter...")
 
   System.in.read()
-  system.shutdown()
+  system.terminate()
 }

--- a/src/main/scala/com/github.sstone/amqp/samples/Consumer2.scala
+++ b/src/main/scala/com/github.sstone/amqp/samples/Consumer2.scala
@@ -40,5 +40,5 @@ object Consumer2 extends App {
   // run the Producer sample now and see what happens
   println("press enter...")
   System.in.read()
-  system.shutdown()
+  system.terminate()
 }

--- a/src/main/scala/com/github.sstone/amqp/samples/Consumer3.scala
+++ b/src/main/scala/com/github.sstone/amqp/samples/Consumer3.scala
@@ -39,5 +39,5 @@ object Consumer3 extends App {
   // run the Producer sample now and see what happens
   println("press enter...")
   System.in.read()
-  system.shutdown()
+  system.terminate()
 }

--- a/src/main/scala/com/github.sstone/amqp/samples/OneToAnyRpc.scala
+++ b/src/main/scala/com/github.sstone/amqp/samples/OneToAnyRpc.scala
@@ -67,5 +67,5 @@ object OneToAnyRpc extends App {
   }
   // wait 10 seconds and shut down
   Thread.sleep(10000)
-  system.shutdown()
+  system.terminate()
 }

--- a/src/main/scala/com/github.sstone/amqp/samples/OneToManyRpc.scala
+++ b/src/main/scala/com/github.sstone/amqp/samples/OneToManyRpc.scala
@@ -73,5 +73,5 @@ object OneToManyRpc extends App {
   }
   // wait 10 seconds and shut down
   Thread.sleep(10000)
-  system.shutdown()
+  system.terminate()
 }

--- a/src/main/scala/com/github.sstone/amqp/samples/Producer.scala
+++ b/src/main/scala/com/github.sstone/amqp/samples/Producer.scala
@@ -25,5 +25,5 @@ object Producer extends App {
 
   // give it some time before shutting everything down
   Thread.sleep(500)
-  system.shutdown()
+  system.terminate()
 }

--- a/src/test/scala/com/github.sstone/amqp/ChannelOwnerSpec.scala
+++ b/src/test/scala/com/github.sstone/amqp/ChannelOwnerSpec.scala
@@ -97,7 +97,7 @@ class ChannelOwnerSpec extends ChannelSpec  {
 
     channelOwner ! DeclareQueue(QueueParameters("NO_SUCH_QUEUE", passive = true))
     expectMsgClass(classOf[Amqp.Error])
-    deadletterProbe.expectNoMsg(1 second)
+    deadletterProbe.expectNoMessage(1 second)
   }
 
   "return requests when not connected" in {

--- a/src/test/scala/com/github.sstone/amqp/ChannelSpec.scala
+++ b/src/test/scala/com/github.sstone/amqp/ChannelSpec.scala
@@ -5,7 +5,7 @@ import akka.actor.{ActorRef, Props, ActorSystem}
 import akka.util.Timeout
 import akka.pattern.{ask, gracefulStop}
 import org.scalatest.{BeforeAndAfter, WordSpecLike}
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import java.util.concurrent.TimeUnit
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -13,7 +13,7 @@ import com.rabbitmq.client.ConnectionFactory
 import com.github.sstone.amqp.Amqp._
 import scala.util.Random
 
-class ChannelSpec extends TestKit(ActorSystem("TestSystem")) with WordSpecLike with ShouldMatchers with BeforeAndAfter with ImplicitSender {
+class ChannelSpec extends TestKit(ActorSystem("TestSystem")) with WordSpecLike with Matchers with BeforeAndAfter with ImplicitSender {
   implicit val timeout = Timeout(5 seconds)
   val connFactory = new ConnectionFactory()
   val uri = system.settings.config.getString("amqp-client-test.rabbitmq.uri")

--- a/src/test/scala/com/github.sstone/amqp/ConnectionOwnerSpec.scala
+++ b/src/test/scala/com/github.sstone/amqp/ConnectionOwnerSpec.scala
@@ -1,6 +1,6 @@
 package com.github.sstone.amqp
 
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import org.scalatest.WordSpecLike
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -16,7 +16,7 @@ import ConnectionOwner.{Connected, CreateChannel, Disconnected}
 import java.util.concurrent.TimeUnit
 
 @RunWith(classOf[JUnitRunner])
-class ConnectionOwnerSpec extends TestKit(ActorSystem("TestSystem")) with WordSpecLike with ShouldMatchers with ImplicitSender {
+class ConnectionOwnerSpec extends TestKit(ActorSystem("TestSystem")) with WordSpecLike with Matchers with ImplicitSender {
   implicit val timeout = Timeout(5 seconds)
 
   "ConnectionOwner" should {

--- a/src/test/scala/com/github.sstone/amqp/ConsumerSpec.scala
+++ b/src/test/scala/com/github.sstone/amqp/ConsumerSpec.scala
@@ -48,7 +48,7 @@ class ConsumerSpec extends ChannelSpec {
 
       // we have 3 pending messages, this one should not be received
       consumer ! Publish("", queue.name, "test".getBytes("UTF-8"))
-      probe.expectNoMsg(500 milliseconds)
+      probe.expectNoMessage(500 milliseconds)
 
       // but if we ack one our our messages we shoule get the 4th delivery
       consumer ! Ack(deliveryTag = delivery1.envelope.getDeliveryTag)
@@ -141,7 +141,7 @@ class ConsumerSpec extends ChannelSpec {
       val Amqp.Ok(CancelConsumer(_), _) = receiveOne(1 second)
 
       producer ! Publish("", queue1.name, "test1".getBytes("UTF-8"))
-      probe.expectNoMsg()
+      probe.expectNoMessage()
     }
     "send consumer cancellation notifications" in {
       val probe = TestProbe()

--- a/src/test/scala/com/github.sstone/amqp/Test1.scala
+++ b/src/test/scala/com/github.sstone/amqp/Test1.scala
@@ -34,5 +34,5 @@ object Test1 extends App {
   // run the Producer sample now and see what happens
   println("press enter...")
   System.in.read()
-  system.shutdown()
+  system.terminate()
 }


### PR DESCRIPTION
* Cross-compile for Scala 2.11.8 and 2.12.6
* Upgrade Akka to 2.5.11 (same version as in Play 2.6.x)
* Fix deprecation and feature warnings
* Use KinjaBuild plugin to publish to jFrog instead of Nexus

Base branch currently in use is `scala2.11_kinja`. Plan is to merge this into `scala2.11_kinja` then rename it to simply `kinja` and make it the base branch.

Testing this: Start RabbitMQ first, then
```
sbt> ++2.11.8
sbt> test
sbt> ++2.12.6
sbt> test
```