### PR TITLE
Add status listeners to newly created channelowner actors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "amqp-client"
 
 organization := "com.kinja"
  
-version := "2.1.0" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
+version := "2.2.0" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
  
 crossScalaVersions := Seq("2.12.6", "2.11.8")
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ scalacOptions ++= Seq(
 
 libraryDependencies ++= Seq(
 	"com.typesafe.akka"    %% "akka-actor"          % akkaVersion % Provided,
-	"com.rabbitmq"         % "amqp-client"          % "5.3.0",
+	"com.rabbitmq"         % "amqp-client"          % "5.6.0",
 	"com.typesafe.akka"    %% "akka-testkit"        % akkaVersion  % Test,
 	"org.scalatest"        %% "scalatest"           % "3.0.5" % Test,
 	"junit"                % "junit"                % "4.12" % Test,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,4 @@ resolvers := Seq(
 credentials += Credentials(Path.userHome / ".ivy2" / ".kinja-artifactory.credentials")
 
 // Kinja build plugin
-addSbtPlugin("com.kinja.sbtplugins" %% "kinja-build-plugin" % "3.2.1")
+addSbtPlugin("com.kinja.sbtplugins" %% "kinja-build-plugin" % "3.2.4")

--- a/src/main/scala/com/github.sstone/amqp/ConnectionOwner.scala
+++ b/src/main/scala/com/github.sstone/amqp/ConnectionOwner.scala
@@ -101,17 +101,20 @@ class ConnectionOwner(connFactory: ConnectionFactory,
   }
 
   /**
-   * ask this connection owner to create a "channel aware" child
+   * ask this connection owner to create a "channel aware" child and
+   * attach the status listeners to it.
    * @param props actor creation properties
    * @param name optional actor name
    * @return a new actor
    */
-  private def createChild(props: Props, name: Option[String]) = {
+  private def createChild(props: Props, name: Option[String]): ActorRef = {
     // why isn't there an actorOf(props: Props, name: Option[String] = None) ?
-    name match {
+    val child = name match {
       case None => context.actorOf(props)
       case Some(actorName) => context.actorOf(props, actorName)
     }
+    statusListeners.foreach(listener => child ! AddStatusListener(listener))
+    child
   }
 
   def createConnection: Connection = {


### PR DESCRIPTION
### What does this PR do? How does it affect users?

Fixing: status listener actors don't  receive channel connection status messages

- ConnectionOwners add statuslisteners to the newly created child actors (ChannelOwner)
- update sbt version to 1.2.8
- update rabbitmq client version to 5.6.0

### How should this be tested (feature switches, URLs, special user permissions)?
sbt test

### Related Asana task, wiki page or blog posts
https://app.asana.com/0/952977657135210/1113145586088102/f