### PR TITLE
Akka 2.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "com.kinja"
  
 version := "2.2.3" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
  
-crossScalaVersions := Seq("2.13.1", "2.12.8")
+crossScalaVersions := Seq("2.13.1")
 
 scalaVersion := crossScalaVersions.value.head
  

--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,13 @@ name := "amqp-client"
 
 organization := "com.kinja"
  
-version := "2.2.2" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
+version := "2.2.3" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
  
-crossScalaVersions := Seq("2.12.8", "2.13.0", "2.11.12")
+crossScalaVersions := Seq("2.13.1", "2.12.8")
 
 scalaVersion := crossScalaVersions.value.head
  
-val akkaVersion = "2.5.23"
+val akkaVersion = "2.6.3"
 
 scalacOptions ++= Seq(
 	"-unchecked",                        // Show details of unchecked warnings.

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "amqp-client"
 
 organization := "com.kinja"
  
-version := "2.2.3" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
+version := "2.3.0" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
  
 crossScalaVersions := Seq("2.13.1")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
 resolvers := Seq(
-	"Kinja Public Group" at sys.env.getOrElse("KINJA_PUBLIC_REPO", "https://kinjajfrog.jfrog.io/kinjajfrog/sbt-virtual"),
+	"Kinja Public" at sys.env.getOrElse("KINJA_PUBLIC_REPO", "https://kinjajfrog.jfrog.io/kinjajfrog/sbt-virtual"),
 	"sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
 )
 
 credentials += Credentials(Path.userHome / ".ivy2" / ".kinja-artifactory.credentials")
 
 // Kinja build plugin
-addSbtPlugin("com.kinja.sbtplugins" %% "kinja-build-plugin" % "3.2.4")
+addSbtPlugin("com.kinja.sbtplugins" %% "kinja-build-plugin" % "3.2.5")

--- a/src/main/scala/com/github.sstone/amqp/ConnectionOwner.scala
+++ b/src/main/scala/com/github.sstone/amqp/ConnectionOwner.scala
@@ -87,7 +87,7 @@ class ConnectionOwner(connFactory: ConnectionFactory,
   var connection: Option[Connection] = None
   val statusListeners = collection.mutable.HashSet.empty[ActorRef]
 
-  val reconnectTimer = context.system.scheduler.schedule(10.milliseconds, reconnectionDelay, self, Connect)
+  val reconnectTimer = context.system.scheduler.scheduleAtFixedRate(10.milliseconds, reconnectionDelay, self, Connect)
 
   override def postStop: Unit = {
     connection.foreach { c =>

--- a/src/main/scala/com/github.sstone/amqp/Consumer.scala
+++ b/src/main/scala/com/github.sstone/amqp/Consumer.scala
@@ -51,7 +51,7 @@ class Consumer(listener: Option[ActorRef],
 
   override def preStart(): Unit = {
     import scala.concurrent.duration._
-    context.system.scheduler.schedule(5.seconds, 5.seconds, self, Consumer.CheckBindings)(context.dispatcher)
+    context.system.scheduler.scheduleAtFixedRate(5.seconds, 5.seconds, self, Consumer.CheckBindings)(context.dispatcher)
     super.preStart()
   }
 

--- a/src/main/scala/com/github.sstone/amqp/samples/Consumer4.scala
+++ b/src/main/scala/com/github.sstone/amqp/samples/Consumer4.scala
@@ -27,14 +27,14 @@ object Consumer4 extends App {
   waitForConnection(system, conn, producer).await(5, TimeUnit.SECONDS)
   producer ! DeclareQueue(QueueParameters(name = "queue1", passive = false, durable = false,  autodelete = false))
   producer ! DeclareQueue(QueueParameters(name = "queue2", passive = false, durable = false,  autodelete = false))
-  system.scheduler.schedule(1.second, 1.second, producer, Publish(exchange = "", key = "queue1", body = "test1".getBytes("UTF-8")))
-  system.scheduler.schedule(1.second, 1.second, producer, Publish(exchange = "", key = "queue2", body = "test2".getBytes("UTF-8")))
+  system.scheduler.scheduleAtFixedRate(1.second, 1.second, producer, Publish(exchange = "", key = "queue1", body = "test1".getBytes("UTF-8")))
+  system.scheduler.scheduleAtFixedRate(1.second, 1.second, producer, Publish(exchange = "", key = "queue2", body = "test2".getBytes("UTF-8")))
 
   class Boot extends Actor with ActorLogging {
     conn ! Create(Consumer.props(listener = self, autoack = false, channelParams = None), name = Some("consumer"))
 
-    context.system.scheduler.schedule(1.second, 10.seconds, self, (Switch, "queue1"))
-    context.system.scheduler.schedule(10.seconds, 10.seconds, self, (Switch, "queue2"))
+    context.system.scheduler.scheduleAtFixedRate(1.second, 10.seconds, self, (Switch, "queue1"))
+    context.system.scheduler.scheduleAtFixedRate(10.seconds, 10.seconds, self, (Switch, "queue2"))
 
     override def unhandled(message: Any): Unit = message match {
       case Delivery(_, envelope, _, body) =>

--- a/src/test/scala/com/github.sstone/amqp/Bug30Spec.scala
+++ b/src/test/scala/com/github.sstone/amqp/Bug30Spec.scala
@@ -30,7 +30,7 @@ object Bug30Spec {
     val producer = ConnectionOwner.createChildActor(conn, ChannelOwner.props())
     Amqp.waitForConnection(context.system, consumer, producer)
 
-    context.system.scheduler.schedule(10.milliseconds, 500.milliseconds, producer, Publish("amq.direct", "my_key", body = "test".getBytes("UTF-8")))
+    context.system.scheduler.scheduleAtFixedRate(10.milliseconds, 500.milliseconds, producer, Publish("amq.direct", "my_key", body = "test".getBytes("UTF-8")))
 
     var counter = 0
 

--- a/src/test/scala/com/github.sstone/amqp/ChannelSpec.scala
+++ b/src/test/scala/com/github.sstone/amqp/ChannelSpec.scala
@@ -2,6 +2,7 @@ package com.github.sstone.amqp
 
 import akka.testkit.{ImplicitSender, TestKit}
 import akka.actor.{ActorRef, ActorSystem}
+import akka.event.Logging
 import akka.util.Timeout
 import akka.pattern.gracefulStop
 import org.scalatest.{BeforeAndAfter, WordSpecLike}
@@ -15,6 +16,7 @@ import scala.util.Random
 
 class ChannelSpec extends TestKit(ActorSystem("TestSystem")) with WordSpecLike with Matchers with BeforeAndAfter with ImplicitSender {
   implicit val timeout = Timeout(5.seconds)
+  val log = Logging(system, this.getClass.getName)
   val connFactory = new ConnectionFactory()
   val uri = system.settings.config.getString("amqp-client-test.rabbitmq.uri")
   connFactory.setUri(uri)
@@ -31,14 +33,14 @@ class ChannelSpec extends TestKit(ActorSystem("TestSystem")) with WordSpecLike w
   def randomKey = "key" + random.nextInt()
 
   before {
-    println("before")
+    log.debug("before")
     conn = system.actorOf(ConnectionOwner.props(connFactory, 1.second))
     channelOwner = ConnectionOwner.createChildActor(conn, ChannelOwner.props())
     waitForConnection(system, conn, channelOwner).await(5, TimeUnit.SECONDS)
   }
 
   after {
-    println("after")
+    log.debug("after")
     Await.result(gracefulStop(conn, 5.seconds), 6.seconds)
   }
 }

--- a/src/test/scala/com/github.sstone/amqp/ConsumerSpec.scala
+++ b/src/test/scala/com/github.sstone/amqp/ConsumerSpec.scala
@@ -1,5 +1,6 @@
 package com.github.sstone.amqp
 
+import akka.event.Logging
 import akka.testkit.TestProbe
 import com.github.sstone.amqp.Amqp._
 import concurrent.duration._
@@ -24,7 +25,7 @@ class ConsumerSpec extends ChannelSpec {
       probe.expectMsg(1.second, ChannelOwner.Connected)
       consumer ! AddBinding(Binding(exchange, queue, "my_key"))
       val check = receiveOne(1.second)
-      println(check)
+      log.debug(check.toString)
       val message = "yo!".getBytes
       producer ! Publish(exchange.name, "my_key", message)
       probe.expectMsgClass(1.second, classOf[Delivery])

--- a/src/test/scala/com/github.sstone/amqp/PendingAcksSpec.scala
+++ b/src/test/scala/com/github.sstone/amqp/PendingAcksSpec.scala
@@ -1,7 +1,6 @@
 package com.github.sstone.amqp
 
-import akka.actor.ActorDSL._
-import akka.actor.{PoisonPill, ActorLogging, Props}
+import akka.actor.{Actor, PoisonPill, ActorLogging, Props}
 import akka.testkit.TestProbe
 import com.github.sstone.amqp.Amqp._
 import org.junit.runner.RunWith
@@ -30,8 +29,8 @@ class PendingAcksSpec extends ChannelSpec with WordSpecLike {
 
       // create a consumer that does not ack messages
       val badListener = system.actorOf(Props {
-        new Act with ActorLogging {
-          become {
+        new Actor with ActorLogging {
+          def receive = {
             case Delivery(_, envelope, _, body) => {
               log.info(s"received ${new String(body, "UTF-8")} tag = ${envelope.getDeliveryTag} redeliver = ${envelope.isRedeliver}")
               counter = counter + 1
@@ -59,8 +58,8 @@ class PendingAcksSpec extends ChannelSpec with WordSpecLike {
       // create a consumer that does ack messages
       var counter1 = 0
       val goodListener = system.actorOf(Props {
-        new Act with ActorLogging {
-          become {
+        new Actor with ActorLogging {
+          def receive = {
             case Delivery(_, envelope, _, body) => {
               log.info(s"received ${new String(body, "UTF-8")} tag = ${envelope.getDeliveryTag} redeliver = ${envelope.isRedeliver}")
               counter1 = counter1 + 1

--- a/src/test/scala/com/github.sstone/amqp/ProducerSpec.scala
+++ b/src/test/scala/com/github.sstone/amqp/ProducerSpec.scala
@@ -28,7 +28,7 @@ class ProducerSpec extends ChannelSpec {
       fishForMessage(1.second) {
         case Amqp.Ok(AddBinding(Binding(`exchange`, `queue`, `routingKey`)), _) => true
         case msg => {
-          println(s"unexpected $msg")
+          log.debug(s"unexpected $msg")
           false
         }
       }

--- a/src/test/scala/com/github.sstone/amqp/RpcSpec.scala
+++ b/src/test/scala/com/github.sstone/amqp/RpcSpec.scala
@@ -28,7 +28,7 @@ class RpcSpec extends ChannelSpec {
       val routingKey = randomKey
       val proc = new RpcServer.IProcessor() {
         def process(delivery: Delivery) = Future {
-          println("processing")
+          log.debug("processing")
           val s = new String(delivery.body)
           if (s == "5") throw new Exception("I dont do 5s")
           ProcessResult(Some(delivery.body))
@@ -47,11 +47,11 @@ class RpcSpec extends ChannelSpec {
           try {
             val future = client1 ? Request(Publish("amq.direct", routingKey, i.toString.getBytes) :: Nil, 1)
             val result = Await.result(future, 1000.millis).asInstanceOf[Response]
-            println("result1 " + new String(result.deliveries.head.body))
+            log.debug("result1 " + new String(result.deliveries.head.body))
             Thread.sleep(300)
           }
           catch {
-            case e: Exception => println(e.toString)
+            case e: Exception => log.debug(e.toString)
           }
         }
       }
@@ -60,11 +60,11 @@ class RpcSpec extends ChannelSpec {
           try {
             val future = client2 ? Request(Publish("amq.direct", routingKey, i.toString.getBytes) :: Nil, 1)
             val result = Await.result(future, 1000.millis).asInstanceOf[Response]
-            println("result2 " + new String(result.deliveries.head.body))
+            log.debug("result2 " + new String(result.deliveries.head.body))
             Thread.sleep(300)
           }
           catch {
-            case e: Exception => println(e.toString)
+            case e: Exception => log.debug(e.toString)
           }
         }
       }


### PR DESCRIPTION
Bumping Akka version to 2.6 because that's what used by the latest Play framework.
This means dropping support for Scala 2.11. And removing Scala 2.12 because we no longer use it.